### PR TITLE
replace filth with unique identifier

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -69,7 +69,7 @@ you can always add your own ``Filth`` and ``Detectors`` like this:
     >>>        # do something here
     >>>        pass
     >>> scrubber = scrubadub.Scrubber()
-    >>> scrubber.add_detector('my filth', MyDetector)
+    >>> scrubber.add_detector(MyDetector)
     >>> text = u"My stuff can be found there"
     >>> scrubadub.clean(text)
     u"{{MINE}} can be found there."

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ latest changes in development for next release
 
 .. THANKS FOR CONTRIBUTING; MENTION WHAT YOU DID IN THIS SECTION HERE!
 
+* Added functionality to keep ``replace_with = "identifier"``
+
 1.0.3
 -----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,9 +35,11 @@ incorporating it into your python scripts like this:
     >>> scrubadub.clean(text)
     u"{{NAME}} is a cat"
 
-..    # Replace names with {{NAME-ID}} anonymous, but consistent IDs.
+    # Replace names with {{NAME-ID}} anonymous, but consistent IDs.
     >>> scrubadub.clean(text, replace_with='identifier')
-    u"{{NAME-1287}} is a cat"
+    u"{{NAME-0}} is a cat"
+    >>> scrubadub.clean("John spoke with Doug.", replace_with='identifier')
+    u"{{NAME-0}} spoke with {{NAME-1}}."
 
 ..    # Replace names with random, gender-consistent names
     >>> scrubadub.clean(text, replace_with='surrogate')

--- a/scrubadub/detectors/__init__.py
+++ b/scrubadub/detectors/__init__.py
@@ -7,9 +7,13 @@ import importlib
 def _iter_module_names():
     this_filename = os.path.abspath(__file__)
     this_dir = os.path.dirname(this_filename)
-    base_filename = os.path.join(this_dir, 'base.py')
+    exclude_filenames = set((
+        this_filename,
+        this_filename.replace('.pyc', '.py'),
+        os.path.join(this_dir, 'base.py'),
+    ))
     for py_filename in sorted(glob.glob(os.path.join(this_dir, '*.py'))):
-        if py_filename != this_filename and py_filename != base_filename:
+        if py_filename not in exclude_filenames:
             filename_root, _ = os.path.splitext(py_filename)
             module_name = os.path.basename(filename_root)
             yield module_name
@@ -38,3 +42,11 @@ def iter_detector_clss():
         detector_cls = _get_detector(module_name)
         if detector_cls is not None:
             yield detector_cls
+
+
+# import all of the detector classes into the local namespace to make it easy
+# to do things like `import scrubadub.detectors.NameDetector`
+# http://stackoverflow.com/a/4526709/564709
+# http://stackoverflow.com/a/511059/564709
+for _detector_cls in iter_detector_clss():
+    locals().update({type(_detector_cls()).__name__: _detector_cls})

--- a/scrubadub/detectors/__init__.py
+++ b/scrubadub/detectors/__init__.py
@@ -8,7 +8,7 @@ def _iter_module_names():
     this_filename = os.path.abspath(__file__)
     this_dir = os.path.dirname(this_filename)
     base_filename = os.path.join(this_dir, 'base.py')
-    for py_filename in glob.glob(os.path.join(this_dir, '*.py')):
+    for py_filename in sorted(glob.glob(os.path.join(this_dir, '*.py'))):
         if py_filename != this_filename and py_filename != base_filename:
             filename_root, _ = os.path.splitext(py_filename)
             module_name = os.path.basename(filename_root)

--- a/scrubadub/detectors/__init__.py
+++ b/scrubadub/detectors/__init__.py
@@ -9,19 +9,24 @@ def _is_abstract_detector(detector_cls):
     return detector_cls.filth_cls is None
 
 
-def iter_detectors():
+def iter_detector_clss():
     """Iterate over all of the detectors that are included in this sub-package.
     This is a convenience method for capturing all new Detectors that are added
     over time and it is used both by the unit tests and in the
     ``Scrubber.__init__`` method.
     """
-    subclass_iterator = iter_subclasses(
+    return iter_subclasses(
         os.path.dirname(os.path.abspath(__file__)),
         Detector,
         _is_abstract_detector,
     )
-    for subclass in subclass_iterator:
-        yield subclass()
+
+
+def iter_detectors():
+    """Iterate over all instances of ``Detector`` subclasses.
+    """
+    for detector_cls in iter_detector_clss():
+        yield detector_cls()
 
 
 # import all of the detector classes into the local namespace to make it easy

--- a/scrubadub/detectors/__init__.py
+++ b/scrubadub/detectors/__init__.py
@@ -1,52 +1,29 @@
-import inspect
-import glob
 import os
-import importlib
+
+from ..import_magic import iter_subclasses, update_locals
+from .base import Detector
 
 
-def _iter_module_names():
-    this_filename = os.path.abspath(__file__)
-    this_dir = os.path.dirname(this_filename)
-    exclude_filenames = set((
-        this_filename,
-        this_filename.replace('.pyc', '.py'),
-        os.path.join(this_dir, 'base.py'),
-    ))
-    for py_filename in sorted(glob.glob(os.path.join(this_dir, '*.py'))):
-        if py_filename not in exclude_filenames:
-            filename_root, _ = os.path.splitext(py_filename)
-            module_name = os.path.basename(filename_root)
-            yield module_name
+def _is_abstract_detector(detector_cls):
+    """Detectors must define a ``filth_cls`` class attribute"""
+    return detector_cls.filth_cls is None
 
 
-# inspect all modules in this directory for subclasses of
-# inherit from BaseRecommender. inpiration from
-# http://stackoverflow.com/q/1796180/564709
-def _get_detector(module_name):
-    from .base import Detector, RegexDetector
-    base_detectors = set([Detector, RegexDetector])
-    module = importlib.import_module('.' + module_name, __package__)
-    for name, obj in inspect.getmembers(module):
-        if inspect.isclass(obj) and issubclass(obj, Detector) \
-                and obj not in base_detectors:
-            return obj
-
-
-def iter_detector_clss():
+def iter_detectors():
     """Iterate over all of the detectors that are included in this sub-package.
     This is a convenience method for capturing all new Detectors that are added
     over time and it is used both by the unit tests and in the
     ``Scrubber.__init__`` method.
     """
-    for module_name in _iter_module_names():
-        detector_cls = _get_detector(module_name)
-        if detector_cls is not None:
-            yield detector_cls
+    subclass_iterator = iter_subclasses(
+        os.path.dirname(os.path.abspath(__file__)),
+        Detector,
+        _is_abstract_detector,
+    )
+    for subclass in subclass_iterator:
+        yield subclass()
 
 
 # import all of the detector classes into the local namespace to make it easy
 # to do things like `import scrubadub.detectors.NameDetector`
-# http://stackoverflow.com/a/4526709/564709
-# http://stackoverflow.com/a/511059/564709
-for _detector_cls in iter_detector_clss():
-    locals().update({type(_detector_cls()).__name__: _detector_cls})
+update_locals(locals(), iter_detectors)

--- a/scrubadub/detectors/__init__.py
+++ b/scrubadub/detectors/__init__.py
@@ -1,17 +1,40 @@
-from .name import NameDetector
-from .email import EmailDetector
-from .url import UrlDetector
-from .phone import PhoneDetector
-from .credential import CredentialDetector
-from .skype import SkypeDetector
+import inspect
+import glob
+import os
+import importlib
 
 
-# convenience object for instantiating all of the detectors at once
-types = {
-    "name": NameDetector,
-    "email": EmailDetector,
-    "url": UrlDetector,
-    "phone": PhoneDetector,
-    "credential": CredentialDetector,
-    "skype": SkypeDetector,
-}
+def _iter_module_names():
+    this_filename = os.path.abspath(__file__)
+    this_dir = os.path.dirname(this_filename)
+    base_filename = os.path.join(this_dir, 'base.py')
+    for py_filename in glob.glob(os.path.join(this_dir, '*.py')):
+        if py_filename != this_filename and py_filename != base_filename:
+            filename_root, _ = os.path.splitext(py_filename)
+            module_name = os.path.basename(filename_root)
+            yield module_name
+
+
+# inspect all modules in this directory for subclasses of
+# inherit from BaseRecommender. inpiration from
+# http://stackoverflow.com/q/1796180/564709
+def _get_detector(module_name):
+    from .base import Detector, RegexDetector
+    base_detectors = set([Detector, RegexDetector])
+    module = importlib.import_module('.' + module_name, __package__)
+    for name, obj in inspect.getmembers(module):
+        if inspect.isclass(obj) and issubclass(obj, Detector) \
+                and obj not in base_detectors:
+            return obj
+
+
+def iter_detector_clss():
+    """Iterate over all of the detectors that are included in this sub-package.
+    This is a convenience method for capturing all new Detectors that are added
+    over time and it is used both by the unit tests and in the
+    ``Scrubber.__init__`` method.
+    """
+    for module_name in _iter_module_names():
+        detector_cls = _get_detector(module_name)
+        if detector_cls is not None:
+            yield detector_cls

--- a/scrubadub/filth/__init__.py
+++ b/scrubadub/filth/__init__.py
@@ -1,7 +1,32 @@
+import os
+import re
+
+from ..import_magic import iter_subclasses, update_locals
 from .base import Filth, MergedFilth, RegexFilth
-from .name import NameFilth
-from .email import EmailFilth
-from .url import UrlFilth
-from .phone import PhoneFilth
-from .credential import CredentialFilth
-from .skype import SkypeFilth
+
+
+def _is_abstract_filth(filth_cls):
+    """Filth must have a ``type`` defined"""
+    return filth_cls.type is None
+
+
+def iter_filths():
+    """Iterate over all of the filths that are included in this sub-package.
+    This is a convenience method for capturing all new Filth that are added
+    over time.
+    """
+    subclass_iterator = iter_subclasses(
+        os.path.dirname(os.path.abspath(__file__)),
+        Filth,
+        _is_abstract_filth,
+    )
+    for subclass in subclass_iterator:
+        if issubclass(subclass, RegexFilth):
+            m = re.finditer(r"\s+", "fake pattern string").next()
+            yield subclass(m)
+        else:
+            yield subclass()
+
+# import all of the detector classes into the local namespace to make it easy
+# to do things like `import scrubadub.detectors.NameDetector`
+update_locals(locals(), iter_filths)

--- a/scrubadub/filth/__init__.py
+++ b/scrubadub/filth/__init__.py
@@ -10,22 +10,26 @@ def _is_abstract_filth(filth_cls):
     return filth_cls.type is None
 
 
-def iter_filths():
+def iter_filth_clss():
     """Iterate over all of the filths that are included in this sub-package.
     This is a convenience method for capturing all new Filth that are added
     over time.
     """
-    subclass_iterator = iter_subclasses(
+    return iter_subclasses(
         os.path.dirname(os.path.abspath(__file__)),
         Filth,
         _is_abstract_filth,
     )
-    for subclass in subclass_iterator:
-        if issubclass(subclass, RegexFilth):
+
+
+def iter_filths():
+    """Iterate over all instances of filth"""
+    for filth_cls in iter_filth_clss():
+        if issubclass(filth_cls, RegexFilth):
             m = re.finditer(r"\s+", "fake pattern string").next()
-            yield subclass(m)
+            yield filth_cls(m)
         else:
-            yield subclass()
+            yield filth_cls()
 
 # import all of the detector classes into the local namespace to make it easy
 # to do things like `import scrubadub.detectors.NameDetector`

--- a/scrubadub/filth/base.py
+++ b/scrubadub/filth/base.py
@@ -1,4 +1,5 @@
 from .. import exceptions
+from .. import utils
 
 
 class Filth(object):
@@ -14,6 +15,10 @@ class Filth(object):
     # the `type` is used when filths are merged to come up with a sane label
     type = None
 
+    # the `lookup` is used to keep track of all of the diffent types of filth
+    # that are encountered across all `Filth` types.
+    lookup = utils.Lookup()
+
     def __init__(self, beg=0, end=0, text=u''):
         self.beg = beg
         self.end = end
@@ -23,13 +28,21 @@ class Filth(object):
     def placeholder(self):
         return self.type.upper()
 
+    @property
+    def identifier(self):
+        # NOTE: this is not an efficient way to store this in memory. could
+        # alternatively hash the type and text and do away with the overhead
+        # bits of storing the tuple in the lookup
+        i = self.lookup[(self.type, self.text.lower())]
+        return u'%s-%d' % (self.placeholder, i)
+
     def replace_with(self, replace_with='placeholder', **kwargs):
         if replace_with == 'placeholder':
             return self.prefix + self.placeholder + self.suffix
         # elif replace_with == 'surrogate':
         #     raise NotImplementedError
-        # elif replace_with == 'identifier':
-        #     raise NotImplementedError
+        elif replace_with == 'identifier':
+            return self.prefix + self.identifier + self.suffix
         else:
             raise exceptions.InvalidReplaceWith(replace_with)
 

--- a/scrubadub/import_magic.py
+++ b/scrubadub/import_magic.py
@@ -1,0 +1,42 @@
+import inspect
+import glob
+import os
+import importlib
+
+
+def _iter_package_module_names(package_root):
+    init_filename = os.path.join(package_root, '__init__.py')
+    for py_filename in sorted(glob.glob(os.path.join(package_root, '*.py'))):
+        if py_filename != init_filename:
+            filename_root, _ = os.path.splitext(py_filename)
+            module_name = os.path.basename(filename_root)
+            yield module_name
+
+
+def _iter_module_subclasses(package, module_name, base_cls):
+    """inspect all modules in this directory for subclasses of inherit from
+    ``base_cls``. inpiration from http://stackoverflow.com/q/1796180/564709
+    """
+    module = importlib.import_module('.' + module_name, package)
+    for name, obj in inspect.getmembers(module):
+        if inspect.isclass(obj) and issubclass(obj, base_cls):
+            yield obj
+
+
+def iter_subclasses(package_root, base_cls, is_abstract):
+    package = 'scrubadub.' + os.path.basename(package_root)
+    for module_name in _iter_package_module_names(package_root):
+        for subclass in _iter_module_subclasses(package, module_name, base_cls):
+            if not is_abstract(subclass):
+                yield subclass
+
+
+def update_locals(locals_instance, instance_iterator, *args, **kwargs):
+    """import all of the detector classes into the local namespace to make it
+    easy to do things like `import scrubadub.detectors.NameDetector` without
+    having to add each new ``Detector`` or ``Filth``
+    """
+    # http://stackoverflow.com/a/4526709/564709
+    # http://stackoverflow.com/a/511059/564709
+    for instance in instance_iterator():
+        locals_instance.update({type(instance).__name__: instance.__class__})

--- a/scrubadub/import_magic.py
+++ b/scrubadub/import_magic.py
@@ -26,9 +26,9 @@ def _iter_module_subclasses(package, module_name, base_cls):
 def iter_subclasses(package_root, base_cls, is_abstract):
     package = 'scrubadub.' + os.path.basename(package_root)
     for module_name in _iter_package_module_names(package_root):
-        for subclass in _iter_module_subclasses(package, module_name, base_cls):
-            if not is_abstract(subclass):
-                yield subclass
+        for cls in _iter_module_subclasses(package, module_name, base_cls):
+            if not is_abstract(cls):
+                yield cls
 
 
 def update_locals(locals_instance, instance_iterator, *args, **kwargs):

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -21,19 +21,22 @@ class Scrubber(object):
         # instantiate all of the detectors which, by default, uses all of the
         # detectors that are in the detectors.types dictionary
         self._detectors = {}
-        for name, detector_cls in detectors.types.iteritems():
-            self.add_detector(name, detector_cls)
+        for detector_cls in detectors.iter_detector_clss():
+            self.add_detector(detector_cls)
 
-    def add_detector(self, name, detector_cls):
+    def add_detector(self, detector_cls):
         """Add a ``Detector`` to scrubadub"""
+        if not issubclass(detector_cls, detectors.base.Detector):
+            raise TypeError((
+                '"%(detector_cls)s" is not a subclass of Detector'
+            ) % locals())
+        # TODO: should add tests to make sure filth_cls is actually a proper
+        # filth_cls
+        name = detector_cls.filth_cls.type
         if self._detectors.has_key(name):
             raise KeyError((
                 'can not add Detector "%(name)s"---it already exists. '
                 'Try removing it first.'
-            ) % locals())
-        if not issubclass(detector_cls, detectors.base.Detector):
-            raise TypeError((
-                '"%(detector_cls)s" is not a subclass of Detector'
             ) % locals())
         self._detectors[name] = detector_cls()
 

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -33,7 +33,7 @@ class Scrubber(object):
         # TODO: should add tests to make sure filth_cls is actually a proper
         # filth_cls
         name = detector_cls.filth_cls.type
-        if self._detectors.has_key(name):
+        if name in self._detectors:
             raise KeyError((
                 'can not add Detector "%(name)s"---it already exists. '
                 'Try removing it first.'

--- a/scrubadub/utils.py
+++ b/scrubadub/utils.py
@@ -37,3 +37,19 @@ class CanonicalStringSet(set):
         return super(CanonicalStringSet, self).discard(
             self._cast_as_lower(element)
         )
+
+
+class Lookup(object):
+    """The Lookup object is used to create an in-memory reference table to
+    create unique identifiers for ``Filth`` that is encountered.
+    """
+
+    def __init__(self):
+        self.table = {}
+
+    def __getitem__(self, key):
+        try:
+            return self.table[key]
+        except KeyError:
+            self.table[key] = len(self.table)
+            return self.table[key]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 with open("README.rst") as stream:
     long_description = stream.read()
 
-github_url='https://github.com/datascopeanalytics/scrubadub'
+github_url = 'https://github.com/datascopeanalytics/scrubadub'
 
 # read in the dependencies from the virtualenv requirements file
 dependencies = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,8 +7,10 @@ import scrubadub
 # functionality of the test suite
 class BaseTestCase(object):
 
-    def clean(self, text):
-        return scrubadub.clean(text)
+    def clean(self, text, **kwargs):
+        if 'replace_with' in kwargs:
+            scrubadub.filth.base.Filth.lookup = scrubadub.utils.Lookup()
+        return scrubadub.clean(text, **kwargs)
 
     def get_before_after(self, docstring=None):
         """Recursively parse the docstrings of methods that are called in the
@@ -37,9 +39,9 @@ class BaseTestCase(object):
             '\nEXPECTED:\n"%s"\n\nBUT GOT THIS:\n"%s"'%(expected, actual),
         )
 
-    def compare_before_after(self, docstring=None):
+    def compare_before_after(self, docstring=None, **clean_kwargs):
         """Convenience method for quickly writing tests using the BEFORE and
         AFTER keywords to parse the docstring.
         """
         before, after = self.get_before_after(docstring=docstring)
-        self.check_equal(after, self.clean(before))
+        self.check_equal(after, self.clean(before, **clean_kwargs))

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -31,3 +31,17 @@ class AdvancedTestCase(unittest.TestCase, BaseTestCase):
         self.check_equal(after, scrubber.clean(before))
         scrubadub.filth.base.Filth.prefix = prefix
         scrubadub.filth.base.Filth.suffix = suffix
+
+    def test_identifier(self):
+        """
+        BEFORE: i'm on skype (dean.malmgren) or can be reached at +1.800.346.1819
+        AFTER:  i'm on skype ({{SKYPE-0}}) or can be reached at {{PHONE-1}}
+        """
+        self.compare_before_after(replace_with='identifier')
+
+    def test_identifier_repeat(self):
+        """
+        BEFORE: my name is Dean Malmgren. Did I mention my name is Dean?
+        AFTER:  my name is {{NAME-0}} {{NAME-1}}. Did I mention my name is {{NAME-0}}?
+        """
+        self.compare_before_after(replace_with='identifier')

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -25,7 +25,7 @@ class RegexDetectorTestCase(unittest.TestCase):
 
     def test_detector_filth_cls(self):
         """Detector.filth_cls should always exist"""
-        for detector_cls in scrubadub.detectors.iter_detector_clss():
+        for detector_cls in scrubadub.detectors.iter_detectors():
             self.assertTrue(getattr(detector_cls, 'filth_cls', False),
                 '%s does not have a filth_cls set' % detector_cls
             )

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -25,7 +25,7 @@ class RegexDetectorTestCase(unittest.TestCase):
 
     def test_detector_filth_cls(self):
         """Detector.filth_cls should always exist"""
-        for name, detector_cls in scrubadub.detectors.types.iteritems():
+        for detector_cls in scrubadub.detectors.iter_detector_clss():
             self.assertTrue(getattr(detector_cls, 'filth_cls', False),
                 '%s does not have a filth_cls set' % detector_cls
             )

--- a/tests/test_filth.py
+++ b/tests/test_filth.py
@@ -11,8 +11,6 @@ class FilthTestCase(unittest.TestCase):
         with self.assertRaises(InvalidReplaceWith):
             filth.replace_with('surrogate')
         with self.assertRaises(InvalidReplaceWith):
-            filth.replace_with('identifier')
-        with self.assertRaises(InvalidReplaceWith):
             filth.replace_with('something_invalid')
 
     def test_nonoverlapping_filth(self):

--- a/tests/test_scrubbers.py
+++ b/tests/test_scrubbers.py
@@ -47,7 +47,7 @@ class ScrubberTestCase(unittest.TestCase):
         """make sure adding a detector that already exists raises an error"""
         scrubber = scrubadub.Scrubber()
         with self.assertRaises(KeyError):
-            scrubber.add_detector('email', scrubadub.detectors.EmailDetector)
+            scrubber.add_detector(scrubadub.detectors.email.EmailDetector)
 
     def test_add_non_detector(self):
         """make sure you can't add a detector that is not a Detector"""
@@ -55,4 +55,4 @@ class ScrubberTestCase(unittest.TestCase):
             pass
         scrubber = scrubadub.Scrubber()
         with self.assertRaises(TypeError):
-            scrubber.add_detector('fargus', NotDetector)
+            scrubber.add_detector(NotDetector)


### PR DESCRIPTION
This also makes it a lot easier to add new `Filth` and `Detector` classes by automatically reading files in the `scrubadub.filth` and `scrubadub.detector` subpackages using `scrubadub.import_magic`. 