### PR TITLE
Make code Python 3 compatible

### DIFF
--- a/scrubadub/detectors/skype.py
+++ b/scrubadub/detectors/skype.py
@@ -44,7 +44,7 @@ class SkypeDetector(RegexDetector):
         for i in skype_indices:
             jmin = max(i-self.word_radius, 0)
             jmax = min(i+self.word_radius+1, len(tokens))
-            for j in range(jmin, i) + range(i+1, jmax):
+            for j in list(range(jmin, i)) + list(range(i+1, jmax)):
                 token = tokens[j]
                 if self.filth_cls.SKYPE_USERNAME.match(token):
 

--- a/scrubadub/filth/__init__.py
+++ b/scrubadub/filth/__init__.py
@@ -26,7 +26,7 @@ def iter_filths():
     """Iterate over all instances of filth"""
     for filth_cls in iter_filth_clss():
         if issubclass(filth_cls, RegexFilth):
-            m = re.finditer(r"\s+", "fake pattern string").next()
+            m = next(re.finditer(r"\s+", "fake pattern string"))
             yield filth_cls(m)
         else:
             yield filth_cls()

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -1,12 +1,9 @@
-import re
 import operator
-
-import textblob
-import nltk
+import sys
 
 from . import exceptions
 from . import detectors
-from .filth import Filth, MergedFilth
+from .filth import Filth
 
 
 class Scrubber(object):
@@ -50,8 +47,9 @@ class Scrubber(object):
         through to the  ``Filth.replace_with`` method to fine-tune how the
         ``Filth`` is cleaned.
         """
-        if not isinstance(text, unicode):
-            raise exceptions.UnicodeRequired
+        if sys.version_info < (3, 0):  # Only in Python 2, in 3 every string is a Python 2 unicode
+            if not isinstance(text, unicode):
+                raise exceptions.UnicodeRequired
 
         clean_chunks = []
         filth = Filth()
@@ -73,7 +71,7 @@ class Scrubber(object):
         # over all detectors simultaneously. just trying to get something
         # working right now and we can worry about efficiency later
         all_filths = []
-        for detector in self._detectors.itervalues():
+        for detector in self._detectors.values():
             for filth in detector.iter_filth(text):
                 if not isinstance(filth, Filth):
                     raise TypeError('iter_filth must always yield Filth')

--- a/scrubadub/utils.py
+++ b/scrubadub/utils.py
@@ -1,3 +1,8 @@
+try:
+    unicode
+except NameError:
+    basestring = str  # Compatibility for Python 2 and 3
+
 
 class CanonicalStringSet(set):
     """Just like a set, except it makes sure that all elements are lower case
@@ -5,7 +10,7 @@ class CanonicalStringSet(set):
     """
 
     def _cast_as_lower(self, x):
-        if not isinstance(x, (str, unicode)):
+        if not isinstance(x, basestring):
             raise TypeError('CanonicalStringSet only works with strings')
         return x.lower()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,11 @@ import inspect
 import scrubadub
 
 
+try:
+    unicode
+except NameError:
+    unicode = str  # Python 2 and 3 compatibility
+
 # this is a mixin class to make it easy to centralize a lot of the core
 # functionality of the test suite
 class BaseTestCase(object):

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,9 +1,11 @@
+import sys
 import unittest
 
 import scrubadub
 
 from base import BaseTestCase
 
+@unittest.skipIf(sys.version_info >= (3,0), "Test only needed in Python 2")
 class UnicodeTestCase(unittest.TestCase, BaseTestCase):
 
     def test_empty(self):


### PR DESCRIPTION
Resolves #27 

This should make the code work in both Python 2 and 3 - at least nosetests pass in both. I hope nothing is too hacky, these seem to be useful tricks (the `basestring=str` one e.g.).
Also removed some unused imports.
