### PR TITLE
Issue #26 Fix for FilthMergeError

### DIFF
--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -78,7 +78,9 @@ class Scrubber(object):
                 if not isinstance(filth, Filth):
                     raise TypeError('iter_filth must always yield Filth')
                 all_filths.append(filth)
-        all_filths.sort(key=operator.attrgetter("beg"))
+                
+        # Sort per start position and substrings
+        all_filths = sorted(all_filths, cmp=_sort_filths)
 
         # this is where the Scrubber does its hard work and merges any
         # overlapping filths.
@@ -92,3 +94,23 @@ class Scrubber(object):
             else:
                 filth = filth.merge(next_filth)
         yield filth
+        
+        
+def _sort_filths(a_filth, b_filth):
+    """Sort list of filths per starting position and substrings"""
+    
+    # if a_filth starts first return a
+    if a_filth.beg < b_filth.beg:
+        return -1
+
+    # if b_filth starts first return b
+    if a_filth.beg > b_filth.beg:
+        return 1
+
+    # if boths filths start in the same position
+    # return the inclusive filth
+    if a_filth.end > b_filth.end:
+        return -1
+
+    return 1
+

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -78,7 +78,7 @@ class Scrubber(object):
                 if not isinstance(filth, Filth):
                     raise TypeError('iter_filth must always yield Filth')
                 all_filths.append(filth)
-                
+
         # Sort per start position and substrings
         all_filths = sorted(all_filths, cmp=_sort_filths)
 
@@ -94,11 +94,11 @@ class Scrubber(object):
             else:
                 filth = filth.merge(next_filth)
         yield filth
-        
-        
+
+
 def _sort_filths(a_filth, b_filth):
     """Sort list of filths per starting position and substrings"""
-    
+
     # if a_filth starts first return a
     if a_filth.beg < b_filth.beg:
         return -1
@@ -113,4 +113,3 @@ def _sort_filths(a_filth, b_filth):
         return -1
 
     return 1
-


### PR DESCRIPTION
MergeFilth was not having in count filths that are substrings of others.
This can be fixed by sorting the filths not only per starting position but also having the inclusive filths first.