### PR TITLE
removing `raise StopIteration` for compatibility with python 3.7

### DIFF
--- a/scrubadub/detectors/base.py
+++ b/scrubadub/detectors/base.py
@@ -19,6 +19,6 @@ class RegexDetector(Detector):
                 'RegexFilth required for RegexDetector'
             )
         if self.filth_cls.regex is None:
-            raise StopIteration
+            return
         for match in self.filth_cls.regex.finditer(text):
             yield self.filth_cls(match)

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -85,7 +85,7 @@ class Scrubber(object):
         # this is where the Scrubber does its hard work and merges any
         # overlapping filths.
         if not all_filths:
-            raise StopIteration
+            return
         filth = all_filths[0]
         for next_filth in all_filths[1:]:
             if filth.end < next_filth.beg:


### PR DESCRIPTION
I ran into some issues using scrubadub in a python 3.7 environment  and was able to fix it by replacing the `StopIteration` that has been deprecated in 3.7 with a simple `return` 